### PR TITLE
Add validation matrix for linux, macos, windows over python versions

### DIFF
--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -11,7 +11,7 @@ jobs:
   validate-matrix:
     strategy:
       matrix:
-        os-version: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-14, macos-15]
+        os-version: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         python-version: [3.11, 3.12]
 
     runs-on: ${{ matrix.os-version }}
@@ -26,6 +26,34 @@ jobs:
       run: |
         python3 -m venv .venv
         source .venv/bin/activate
+        python3 -m pip install pip --upgrade pylint
+        pylint qdox.py
+
+    - name: Validate
+      run: |
+        python3 -m pip install .
+        mv docs/index.html docs/validate.html
+        python3 -m qdox --withcss
+        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr && false)
+
+  validate-matrix:
+    strategy:
+      matrix:
+        os-version: [windows-2022]
+        python-version: [3.11, 3.12]
+
+    runs-on: ${{ matrix.os-version }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Lint
+      run: |
+        python3 -m venv .venv
+        .venv/bin/activate
         python3 -m pip install pip --upgrade pylint
         pylint qdox.py
 

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -53,7 +53,7 @@ jobs:
     - name: Lint
       run: |
         python3 -m venv .venv
-        . .venv/bin/activate
+        . .venv/scripts/activate
         python3 -m pip install pip --upgrade pylint
         pylint qdox.py
 

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -8,98 +8,19 @@ on:
 
 jobs:
 
-  validate-ubuntu22_x64-python3_11:
-    runs-on: ubuntu-22.04
+  validate-matrix:
+    strategy:
+      matrix:
+        os-version: [ubuntu-22.04, ubuntu-24.02, windows-2022]
+        python-version: [3.11, 3.12]
+
+    runs-on: ${{ matrix.os-version }}
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
-
-    - name: Lint
-      run: |
-        python3 -m pip install --user pip --upgrade pylint
-        pylint qdox.py
-
-    - name: Validate
-      run: |
-        python3 -m pip install .
-        mv docs/index.html docs/validate.html
-        python3 -m qdox --withcss
-        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
-
-  validate-ubuntu22_x64-python3_12:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-
-    - name: Lint
-      run: |
-        python3 -m pip install --user pip --upgrade pylint
-        pylint qdox.py
-
-    - name: Validate
-      run: |
-        python3 -m pip install .
-        mv docs/index.html docs/validate.html
-        python3 -m qdox --withcss
-        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
-
-  validate-ubuntu24_x64-python3_11:
-    runs-on: ubuntu-24.04
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
-    - name: Lint
-      run: |
-        python3 -m pip install --user pip --upgrade pylint
-        pylint qdox.py
-
-    - name: Validate
-      run: |
-        python3 -m pip install .
-        mv docs/index.html docs/validate.html
-        python3 -m qdox --withcss
-        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
-
-  validate-ubuntu24_x64-python3_12:
-    runs-on: ubuntu-24.04
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-
-    - name: Lint
-      run: |
-        python3 -m pip install --user pip --upgrade pylint
-        pylint qdox.py
-
-    - name: Validate
-      run: |
-        python3 -m pip install .
-        mv docs/index.html docs/validate.html
-        python3 -m qdox --withcss
-        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
-
-  validate-ubuntu24_x64-python3_13:
-    runs-on: ubuntu-24.04
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.13'
+        python-version: ${{ matrix.python-version }}
 
     - name: Lint
       run: |

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
 
+  continue-on-error: true
+
   validate-matrix-linux:
     strategy:
       matrix:

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -53,7 +53,7 @@ jobs:
     - name: Lint
       run: |
         python3 -m venv .venv
-        .venv/bin/activate
+        . .venv/bin/activate
         python3 -m pip install pip --upgrade pylint
         pylint qdox.py
 

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -11,7 +11,7 @@ jobs:
   validate-matrix:
     strategy:
       matrix:
-        os-version: [ubuntu-22.04, ubuntu-24.04, windows-2022]
+        os-version: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-14, macos-15]
         python-version: [3.11, 3.12]
 
     runs-on: ${{ matrix.os-version }}

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -48,3 +48,24 @@ jobs:
         mv docs/index.html docs/validate.html
         python3 -m qdox --withcss
         diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
+
+  validate-ubuntu-python3_13:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Lint
+      run: |
+        python3 -m pip install --user pip --upgrade pylint
+        pylint qdox.py
+
+    - name: Validate
+      run: |
+        python3 -m pip install .
+        mv docs/index.html docs/validate.html
+        python3 -m qdox --withcss
+        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  validate:
+  validate-ubuntu-python3_11:
     runs-on: ubuntu-latest
 
     steps:
@@ -15,6 +15,27 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+
+    - name: Lint
+      run: |
+        python3 -m pip install --user pip --upgrade pylint
+        pylint qdox.py
+
+    - name: Validate
+      run: |
+        python3 -m pip install .
+        mv docs/index.html docs/validate.html
+        python3 -m qdox --withcss
+        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
+
+  validate-ubuntu-python3_12:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
 
     - name: Lint
       run: |

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -24,6 +24,8 @@ jobs:
 
     - name: Lint
       run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
         python3 -m pip install --user pip --upgrade pylint
         pylint qdox.py
 

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -26,7 +26,7 @@ jobs:
       run: |
         python3 -m venv .venv
         source .venv/bin/activate
-        python3 -m pip install --user pip --upgrade pylint
+        python3 -m pip install pip --upgrade pylint
         pylint qdox.py
 
     - name: Validate

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -11,7 +11,35 @@ jobs:
   validate-matrix-linux:
     strategy:
       matrix:
-        os-version: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        os-version: [ubuntu-22.04, ubuntu-24.04]
+        python-version: [3.11, 3.12]
+
+    runs-on: ${{ matrix.os-version }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Lint
+      run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+        python3 -m pip install pip --upgrade pylint
+        pylint qdox.py
+
+    - name: Validate
+      run: |
+        python3 -m pip install .
+        mv docs/index.html docs/validate.html
+        python3 -m qdox --withcss
+        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr && false)
+
+  validate-matrix-macos:
+    strategy:
+      matrix:
+        os-version: [macos-13, macos-14, macos-15]
         python-version: [3.11, 3.12]
 
     runs-on: ${{ matrix.os-version }}
@@ -39,7 +67,7 @@ jobs:
   validate-matrix-windows:
     strategy:
       matrix:
-        os-version: [windows-2022]
+        os-version: [windows-2019, windows-2022]
         python-version: [3.11, 3.12]
 
     runs-on: ${{ matrix.os-version }}

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -8,8 +8,6 @@ on:
 
 jobs:
 
-  continue-on-error: true
-
   validate-matrix-linux:
     strategy:
       matrix:
@@ -17,6 +15,7 @@ jobs:
         python-version: [3.11, 3.12]
 
     runs-on: ${{ matrix.os-version }}
+    continue-on-error: true
 
     steps:
     - uses: actions/checkout@v4
@@ -45,6 +44,7 @@ jobs:
         python-version: [3.11, 3.12]
 
     runs-on: ${{ matrix.os-version }}
+    continue-on-error: true
 
     steps:
     - uses: actions/checkout@v4
@@ -73,6 +73,7 @@ jobs:
         python-version: [3.11, 3.12]
 
     runs-on: ${{ matrix.os-version }}
+    continue-on-error: true
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -11,7 +11,7 @@ jobs:
   validate-matrix:
     strategy:
       matrix:
-        os-version: [ubuntu-22.04, ubuntu-24.02, windows-2022]
+        os-version: [ubuntu-22.04, ubuntu-24.04, windows-2022]
         python-version: [3.11, 3.12]
 
     runs-on: ${{ matrix.os-version }}
@@ -32,5 +32,5 @@ jobs:
         python3 -m pip install .
         mv docs/index.html docs/validate.html
         python3 -m qdox --withcss
-        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
+        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr && false)
 

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -7,8 +7,9 @@ on:
     branches: [main]
 
 jobs:
-  validate-ubuntu-python3_11:
-    runs-on: ubuntu-latest
+
+  validate-ubuntu22_x64-python3_11:
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -28,8 +29,8 @@ jobs:
         python3 -m qdox --withcss
         diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
 
-  validate-ubuntu-python3_12:
-    runs-on: ubuntu-latest
+  validate-ubuntu22_x64-python3_12:
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -49,8 +50,50 @@ jobs:
         python3 -m qdox --withcss
         diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
 
-  validate-ubuntu-python3_13:
-    runs-on: ubuntu-latest
+  validate-ubuntu24_x64-python3_11:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Lint
+      run: |
+        python3 -m pip install --user pip --upgrade pylint
+        pylint qdox.py
+
+    - name: Validate
+      run: |
+        python3 -m pip install .
+        mv docs/index.html docs/validate.html
+        python3 -m qdox --withcss
+        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
+
+  validate-ubuntu24_x64-python3_12:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Lint
+      run: |
+        python3 -m pip install --user pip --upgrade pylint
+        pylint qdox.py
+
+    - name: Validate
+      run: |
+        python3 -m pip install .
+        mv docs/index.html docs/validate.html
+        python3 -m qdox --withcss
+        diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
+
+  validate-ubuntu24_x64-python3_13:
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -69,3 +112,4 @@ jobs:
         mv docs/index.html docs/validate.html
         python3 -m qdox --withcss
         diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr;false)
+

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  validate-matrix:
+  validate-matrix-linux:
     strategy:
       matrix:
         os-version: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
@@ -36,7 +36,7 @@ jobs:
         python3 -m qdox --withcss
         diff docs/index.html docs/validate.html || (echo '***ERROR***: Did you forget to run `make` before pushing your latest changes?' >/dev/stderr && false)
 
-  validate-matrix:
+  validate-matrix-windows:
     strategy:
       matrix:
         os-version: [windows-2022]

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
     <h1 id="main" class="w3-container">Command Line</h1>
 
     <p/>
-Generate docs/index.html from module and README.md
+Generate docs/index.html from module contents and metadata
 <p/>Syntax: <code>qdox [OPTION ...]</code><p/>
 <h2 class="w3-container">Options</h2>
 <p/><ul><li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@ Generate docs/index.html from module contents and metadata
 <h1 id="package" class="w3-container">Package Metadata</h1>
 <p/><table class="w3-container">
 <tr><th><nobr>Name</nobr></th><td>:</td><td>qdox</td></tr>
-<tr><th><nobr>Version</nobr></th><td>:</td><td>0.0.0a1</td></tr>
+<tr><th><nobr>Version</nobr></th><td>:</td><td>0.0.0a2</td></tr>
 <tr><th><nobr>Description</nobr></th><td>:</td><td>Generate quick documentation for a Python project on GitHub</td></tr>
 <tr><th><nobr>Authors</nobr></th><td>:</td><td>David P. Chassin <dpchassin@gmail.com></td></tr>
 <tr><th><nobr>Maintainers</nobr></th><td>:</td><td>David P. Chassin <dpchassin@gmail.com></td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,9 +40,9 @@ Generate docs/index.html from module contents and metadata
 
 <h2 class="w3-container">Description</h2>
 <p/>  The <code>qdox</code> command generates the documentation for a simple Python
-  project. The formatting is meants to use simple text layout as the input so
-  that the input can be used for both Python <code>help()</code> and the documentation
-  pages.
+  project. The formatting is designed to use simple text layout as the input 
+  so that the same documentation source can be used for both Python <code>help()</code> 
+  output and the documentation pages.
 <p/>  The command loads the module specified in the <code>pyproject.toml</code> file and
   outputs the <code>__doc__</code> property of the module as the command line
   documentation. It then outputs the python functions and constants,

--- a/docs/index.html
+++ b/docs/index.html
@@ -78,7 +78,8 @@ Generate docs/index.html from module contents and metadata
 <code><code>!!text!!</code></code>:  <font class="highlight">Highlight</font> text</li><li>
 <code><code>~~text~~</code></code>:  <strike>strikeout</strike> text</li><li>
 <code><code>__text__</code></code>:  <u>underline</u> text</li><li>
-<code><code>^word</code></code>:  <sup>superscript</sup> word (ends at space)</li><li>
+<code><code>^word</code></code>:  <sup>superscript</sup> word (ends at space)<pre>
+</pre></li><li>
 <code><code>_word</code></code>:  <sub>subscript</sub> word (ends at space)</li><li>
 <code>`text`</code>:  <code>code</code> text</li><li>
 <code><code>protocol</code>: //url/</code>: <a href="protocol://url/" target="_tab">protocol://url/</a> formatting with active link</li></li>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = []
 
 [project]
 name = "qdox"
-version = "0.0.0a1"
+version = "0.0.0a2"
 description = "Generate quick documentation for a Python project on GitHub"
 authors = [
     {name = "David P. Chassin <dpchassin@gmail.com>"},

--- a/qdox.py
+++ b/qdox.py
@@ -85,8 +85,11 @@ Text Formatting:
     * `!!text!!`: !!Highlight!! text
 
     * `~~text~~`: ~~strikeout~~ text
+
     * `__text__`: __underline__ text
+
     * `^word`: ^superscript word (ends at space)
+    
     * `_word`: _subscript word (ends at space)
 
     * ``text``: `code` text

--- a/qdox.py
+++ b/qdox.py
@@ -174,6 +174,8 @@ def _main(argv:list[str]=sys.argv) -> int:
 
     org = homepage.split("/")[-2]
     github_data = _get_json(f"https://api.github.com/users/{org}")
+    if "error" in github_data:
+        raise QdoxError(github_data["message"])
 
     os.makedirs("docs",exist_ok=True)
 

--- a/qdox.py
+++ b/qdox.py
@@ -1,4 +1,4 @@
-"""Generate docs/index.html from module and README.md
+"""Generate docs/index.html from module contents and metadata
 
 Syntax: qdox [OPTION ...]
 

--- a/qdox.py
+++ b/qdox.py
@@ -115,19 +115,19 @@ def _get_json(*args,**kwargs):
         with requests.get(*args,**kwargs,timeout=60) as res:
             if res.status_code == 200:
                 return json.loads(res.text)
-            qargs = ",".join([repr(x) for x in args]) + \
-                ",".join([f"{str(x)}={repr(y)}" for x,y in kwargs.items()])
+            qargs = [repr(x) for x in args] + \
+                [f"{str(x)}={repr(y)}" for x,y in kwargs.items()]
             return {
                 "error": "request failed", 
-                "message": f"requests.get({qargs}) -> StatusCode={res.status_code}",
+                "message": f"requests.get({','.join(qargs)}) -> StatusCode={res.status_code}",
                 }
     except:
         e_type, e_name, _ = sys.exc_info()
-        qargs = ",".join([repr(x) for x in args]) + \
-            ",".join([f"{str(x)}={repr(y)}" for x,y in kwargs.items()])
+        qargs = [repr(x) for x in args] + \
+            [f"{str(x)}={repr(y)}" for x,y in kwargs.items()]
         return {
             "error": "request failed", 
-            "message": f"requests.get({qargs}) -> {e_type.__name__}={e_name}",
+            "message": f"requests.get({','.join(qargs)}) -> {e_type.__name__}={e_name}",
             }
 
 class QdoxError(Exception):

--- a/qdox.py
+++ b/qdox.py
@@ -115,10 +115,20 @@ def _get_json(*args,**kwargs):
         with requests.get(*args,**kwargs,timeout=60) as res:
             if res.status_code == 200:
                 return json.loads(res.text)
-            return {"error": "request failed", "message": f"StatusCode:{res.status_code}"}
+            qargs = ",".join([repr(x) for x in args]) + \
+                ",".join([f"{str(x)}={repr(y)}" for x,y in kwargs.items()])
+            return {
+                "error": "request failed", 
+                "message": f"requests.get({qargs}) -> StatusCode={res.status_code}",
+                }
     except:
         e_type, e_name, _ = sys.exc_info()
-        return {"error": "request failed", "message": f"{e_type.__name__}={e_name}"}
+        qargs = ",".join([repr(x) for x in args]) + \
+            ",".join([f"{str(x)}={repr(y)}" for x,y in kwargs.items()])
+        return {
+            "error": "request failed", 
+            "message": f"requests.get({qargs}) -> {e_type.__name__}={e_name}",
+            }
 
 class QdoxError(Exception):
     """Error caused by an invalid or missing command line option"""


### PR DESCRIPTION
Now validates ubuntu-{22,24}, macos-{13,14,15}, and windows-20{19,22} over python-{11,12}